### PR TITLE
Require base 4.9.1.0 (ghc 8.0.2) due to usage of withForeignPtr et al

### DIFF
--- a/binary-parser.cabal
+++ b/binary-parser.cabal
@@ -50,7 +50,7 @@ library
     mtl == 2.*,
     transformers >= 0.4 && < 0.6,
     base-prelude < 2,
-    base >= 4.7 && < 5
+    base >= 4.9.1.0 && < 5
 
 test-suite tests
   type:


### PR DESCRIPTION
I published a revision for binary-parser 0.5.5 adding this lower bound