### PR TITLE
require base-prelude >= 1.2

### DIFF
--- a/binary-parser.cabal
+++ b/binary-parser.cabal
@@ -49,7 +49,7 @@ library
     -- general:
     mtl == 2.*,
     transformers >= 0.4 && < 0.6,
-    base-prelude < 2,
+    base-prelude >= 1.2 && < 2,
     base >= 4.7 && < 5
 
 test-suite tests


### PR DESCRIPTION
Second attempt, I managed to reproduce it now. I made the lower bound `>= 1.2` even though `>= 1.0.2` would be sufficient since 1.0.2 and 1.1 are deprecated. You or me can add a revision if you agree.

```
$ stack build binary-parser-0.5.5 --resolver nightly-2017-04-14 base-prelude-1.0.1.1
binary-parser-0.5.5: configure
binary-parser-0.5.5: build

--  While building package binary-parser-0.5.5 using:
      /Users/adam.bergmark/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_1.24.2.0_ghc-8.0.2 --builddir=.stack-work/dist/x86_64-osx/Cabal-1.24.2.0 build --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
    Logs have been written to: /Users/adam.bergmark/.stack/global-project/.stack-work/logs/binary-parser-0.5.5.log

    Configuring binary-parser-0.5.5...
    Building binary-parser-0.5.5...
    Preprocessing library binary-parser-0.5.5...
    [1 of 2] Compiling BinaryParser.Prelude ( library/BinaryParser/Prelude.hs, .stack-work/dist/x86_64-osx/Cabal-1.24.2.0/build/BinaryParser/Prelude.o )
    [2 of 2] Compiling BinaryParser     ( library/BinaryParser.hs, .stack-work/dist/x86_64-osx/Cabal-1.24.2.0/build/BinaryParser.o )

    /private/var/folders/cy/xn12j90n7l74stpfxqkshz31lvpm4_/T/stack8961/binary-parser-0.5.5/library/BinaryParser.hs:198:43: error:
        • Variable not in scope:
            withForeignPtr
              :: GHC.ForeignPtr.ForeignPtr Word8 -> (t2 -> t0) -> IO a
        • Perhaps you meant one of these:
            ‘A.toForeignPtr’ (imported from Data.ByteString.Internal),
            ‘A.nullForeignPtr’ (imported from Data.ByteString.Internal),
            ‘A.fromForeignPtr’ (imported from Data.ByteString.Internal)

    /private/var/folders/cy/xn12j90n7l74stpfxqkshz31lvpm4_/T/stack8961/binary-parser-0.5.5/library/BinaryParser.hs:198:78: error:
        Variable not in scope: peekByteOff :: t1 -> Int -> t0

    /private/var/folders/cy/xn12j90n7l74stpfxqkshz31lvpm4_/T/stack8961/binary-parser-0.5.5/library/BinaryParser.hs:198:91: error:
        Variable not in scope: castPtr :: t2 -> t1
```