### PR TITLE
Relax test upper bounds.

### DIFF
--- a/binary-parser.cabal
+++ b/binary-parser.cabal
@@ -66,9 +66,9 @@ test-suite tests
   build-depends:
     binary-parser,
     -- testing:
-    tasty == 0.11.*,
-    tasty-quickcheck == 0.8.*,
-    tasty-hunit == 0.9.*,
+    tasty >= 0.11 && <= 1.3,
+    tasty-quickcheck >= 0.8 && < 0.11,
+    tasty-hunit >= 0.9 && < 0.11,
     quickcheck-instances >= 0.3.11 && < 0.4,
     -- general:
     rerebase == 1.*


### PR DESCRIPTION
This allows the test suite to run successfully with stackage-lts/ghc8.6. 