### PR TITLE
expose BinaryParser constructor in Internal module

### DIFF
--- a/binary-parser.cabal
+++ b/binary-parser.cabal
@@ -1,7 +1,7 @@
 name:
   binary-parser
 version:
-  0.5.5
+  0.5.6
 synopsis:
   A highly-efficient but limited parser API specialised for bytestrings
 category:

--- a/binary-parser.cabal
+++ b/binary-parser.cabal
@@ -42,6 +42,7 @@ library
     BinaryParser.Prelude
   exposed-modules:
     BinaryParser
+    BinaryParser.Internal
   build-depends:
     -- data:
     bytestring >= 0.10 && < 0.11,

--- a/library/BinaryParser.hs
+++ b/library/BinaryParser.hs
@@ -32,19 +32,7 @@ import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Unsafe as ByteString
 import qualified Data.ByteString.Internal as A
 import qualified BinaryParser.Prelude as B
-
-
--- |
--- A highly-efficient parser specialised for strict 'ByteString's.
--- 
--- Supports the roll-back and alternative branching
--- on the basis of the 'Alternative' interface.
--- 
--- Does not generate fancy error-messages,
--- which contributes to its efficiency.
-newtype BinaryParser a =
-  BinaryParser ( StateT ByteString ( Except Text ) a )
-  deriving ( Functor , Applicative , Alternative , Monad , MonadPlus , MonadError Text )
+import BinaryParser.Internal(BinaryParser(..))
 
 -- |
 -- Apply a parser to bytes.

--- a/library/BinaryParser/Internal.hs
+++ b/library/BinaryParser/Internal.hs
@@ -1,0 +1,15 @@
+module BinaryParser.Internal where
+
+import BinaryParser.Prelude hiding (fold)
+
+-- |
+-- A highly-efficient parser specialised for strict 'ByteString's.
+--
+-- Supports the roll-back and alternative branching
+-- on the basis of the 'Alternative' interface.
+--
+-- Does not generate fancy error-messages,
+-- which contributes to its efficiency.
+newtype BinaryParser a =
+  BinaryParser ( StateT ByteString ( Except Text ) a )
+  deriving ( Functor , Applicative , Alternative , Monad , MonadPlus , MonadError Text )

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -9,7 +9,7 @@ import qualified Data.ByteString as A
 import qualified Data.ByteString.Builder as C
 import qualified Data.ByteString.Lazy as D
 import qualified BinaryParser as B
-
+import BinaryParser.Internal
 
 main =
   defaultMain $
@@ -23,6 +23,8 @@ main =
     ,
     expectedResultTest "byte consumes" ((,) <$> B.byte <*> B.beWord32) (49, 4) "1\NUL\NUL\NUL\EOT"
     ,
+    coercionTest
+    ,
     expectedResultTest "Applicative composition" ((,) <$> B.beWord16 <*> B.beWord16) (1, 2) "\NUL\SOH\NUL\STX"
     ,
     let parser =
@@ -32,6 +34,12 @@ main =
             return (a, b)
         in expectedResultTest "Monadic composition" parser (1, 2) "\NUL\SOH\NUL\STX"
   ]
+
+newtype MyWord16 = MyWord16 Word16
+  deriving (Eq,Show)
+
+coercionTest = testCase "coercionTest" $ 
+  assertEqual "MyWord16" (MyWord16 <$> B.run B.beWord16 "\NUL\SOH") (B.run (coerce B.beWord16) "\NUL\SOH")
 
 builderIsomporhismProperty details parser valueToBuilder =
   testProperty name $ \value ->

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -9,7 +9,7 @@ import qualified Data.ByteString as A
 import qualified Data.ByteString.Builder as C
 import qualified Data.ByteString.Lazy as D
 import qualified BinaryParser as B
-import BinaryParser.Internal
+import BinaryParser.Internal(BinaryParser(..))
 
 main =
   defaultMain $
@@ -38,7 +38,7 @@ main =
 newtype MyWord16 = MyWord16 Word16
   deriving (Eq,Show)
 
-coercionTest = testCase "coercionTest" $ 
+coercionTest = testCase "coercionTest" $
   assertEqual "MyWord16" (MyWord16 <$> B.run B.beWord16 "\NUL\SOH") (B.run (coerce B.beWord16) "\NUL\SOH")
 
 builderIsomporhismProperty details parser valueToBuilder =


### PR DESCRIPTION
In Squeal, we'd like to be able to derive some binary decodings. For this to work, newtype deriving has to be able to see through the `BinaryParser` type, so the constructors would have to be exposed. I understand that this is an implementation detail which is presumably why you haven't exposed it, but if you could expose it in an Internal module as I have done in this PR, people like @echatav and I would be grateful, and promise not to complain if you change it at zero notice without a PVP bump.

demonstration of what it allows is here:

https://github.com/mwotton/squeal/commit/812886d8717281e4fe249ece1f4f40bb10544b9f