### PR TITLE
Remove re-export of Data.Functor for compatibility with base-4.19

### DIFF
--- a/library/BinaryParser/Prelude.hs
+++ b/library/BinaryParser/Prelude.hs
@@ -38,7 +38,6 @@ import Data.Either as Exports
 import Data.Fixed as Exports
 import Data.Foldable as Exports
 import Data.Function as Exports hiding (id, (.))
-import Data.Functor as Exports
 import Data.Functor.Identity as Exports
 import Data.IORef as Exports
 import Data.Int as Exports


### PR DESCRIPTION
Hi, this PR fixes the following issue when building with `base-4.19`:

```
library/BinaryParser/Prelude.hs:2:5: error: [GHC-69158]
    Conflicting exports for ‘unzip’:
       ‘module Exports’ exports ‘Exports.unzip’
         imported from ‘Data.Functor’ at library/BinaryParser/Prelude.hs:41:1-30
       ‘module Exports’ exports ‘Exports.unzip’
         imported from ‘Prelude’ at library/BinaryParser/Prelude.hs:86:1-197
         (and originally defined in ‘GHC.List’)
  |
2 |   ( module Exports,
  |     ^^^^^^^^^^^^^^
```

I elected to simply remove the re-export of `Data.Functor` from `BinaryParser.Prelude`, as its symbols are not used by the rest of the package. I'm sure there are other options that you may prefer, though!